### PR TITLE
fix (mobileSelect) fix event errors on firefox (63.0.3-x64)

### DIFF
--- a/js/mobileSelect.js
+++ b/js/mobileSelect.js
@@ -80,11 +80,11 @@
 
 
 			//按钮监听
-			_this.cancelBtn.addEventListener('click',function(){
+			_this.cancelBtn.addEventListener('click',function(event){
 				_this.hide();
 		    });
 
-		    _this.ensureBtn.addEventListener('click',function(){
+		    _this.ensureBtn.addEventListener('click',function(event){
 				_this.hide();
 			    if(!_this.liHeight) {
 			        _this.liHeight =  _this.mobileSelect.querySelector('li').offsetHeight;
@@ -101,13 +101,13 @@
 		    	_this.callback(_this.curIndexArr, _this.curValue);
 		    });
 
-		    _this.trigger.addEventListener('click',function(){
+		    _this.trigger.addEventListener('click',function(event){
 		    	_this.show();
 		    });
-		    _this.grayLayer.addEventListener('click',function(){
+		    _this.grayLayer.addEventListener('click',function(event){
 				_this.hide();
 		    });
-		    _this.popUp.addEventListener('click',function(){
+		    _this.popUp.addEventListener('click',function(event){
 		    	event.stopPropagation();
 		    });
 
@@ -243,25 +243,25 @@
 
 		addListenerWheel: function(theWheel, index){
 			var _this = this;
-			theWheel.addEventListener('touchstart', function () {
+			theWheel.addEventListener('touchstart', function (event) {
 				_this.touch(event, this.firstChild, index);
 			},false);
-			theWheel.addEventListener('touchend', function () {
+			theWheel.addEventListener('touchend', function (event) {
 				_this.touch(event, this.firstChild, index);
 			},false);
-			theWheel.addEventListener('touchmove', function () {
+			theWheel.addEventListener('touchmove', function (event) {
 				_this.touch(event, this.firstChild, index);
 			},false);
 
 			if(_this.isPC){
 				//如果是PC端则再增加拖拽监听 方便调试
-				theWheel.addEventListener('mousedown', function () {
+				theWheel.addEventListener('mousedown', function (event) {
 					_this.dragClick(event, this.firstChild, index);
 				},false);
-				theWheel.addEventListener('mousemove', function () {
+				theWheel.addEventListener('mousemove', function (event) {
 					_this.dragClick(event, this.firstChild, index);
 				},false);
-				theWheel.addEventListener('mouseup', function () {
+				theWheel.addEventListener('mouseup', function (event) {
 					_this.dragClick(event, this.firstChild, index);
 				},true);
 			}


### PR DESCRIPTION
On Firefox Select doesn't work ever. 

In console I see any errors like:
![capture](https://user-images.githubusercontent.com/1508440/49604617-69815500-f99f-11e8-956d-1898d67f23ed.PNG)
