### PR TITLE
Fix innerHTML of undefined error

### DIFF
--- a/js/mobileSelect.js
+++ b/js/mobileSelect.js
@@ -558,8 +558,8 @@
 
 	    getInnerHtml: function(sliderIndex){
 	    	var _this = this;
-                var lengthOfList = _this.slider[sliderIndex].getElementsByTagName("li").length;
-                var index = _this.getIndex(_this.curDistance[sliderIndex]);
+	    	var lengthOfList = _this.slider[sliderIndex].getElementsByTagName("li").length;
+	    	var index = _this.getIndex(_this.curDistance[sliderIndex]);
 	    	
 	    	if (index >= lengthOfList) {
 	    		index = lengthOfList - 1;

--- a/js/mobileSelect.js
+++ b/js/mobileSelect.js
@@ -558,7 +558,14 @@
 
 	    getInnerHtml: function(sliderIndex){
 	    	var _this = this;
-	    	var index = _this.getIndex(_this.curDistance[sliderIndex]);
+                var lengthOfList = _this.slider[sliderIndex].getElementsByTagName("li").length;
+                var index = _this.getIndex(_this.curDistance[sliderIndex]);
+	    	
+	    	if (index >= lengthOfList) {
+	    		index = lengthOfList - 1;
+	    	} else if (index < 0) {
+	    		index = 0;
+	    	}
 	    	return _this.slider[sliderIndex].getElementsByTagName('li')[index].innerHTML;
 	    },
 


### PR DESCRIPTION
This might happen while dragging really quickly.

https://github.com/onlyhom/mobileSelect.js/blob/master/js/mobileSelect.js#L474
Above `getIndex` will cause the array overflow issue and get an `innerHTML of undefined` error in 
https://github.com/onlyhom/mobileSelect.js/blob/master/js/mobileSelect.js#L562

I think this project has unmaintained for a long while and with some outdated coding style/guideline. I hope that this part of the small fix can be merged into It and help others.